### PR TITLE
Align shellcheck baseline for modular source paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Shellcheck
         run: |
-          find . -name '*.sh' -print0 | xargs -0 shellcheck
+          find . -name '*.sh' -print0 | xargs -0 shellcheck --exclude=SC1090,SC1091
 
       - name: shfmt check (advisory)
         run: |

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,3 @@
 # Keep suppressions minimal and documented.
-# SC1091: sourced files may be dynamic/non-constant in modular shell projects.
-exclude=SC1091
+# SC1090/SC1091: sourced files may be dynamic/non-constant in modular shell projects.
+exclude=SC1090,SC1091

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 lint:
 	find . -name '*.sh' -print0 | xargs -0 -n1 bash -n
-	find . -name '*.sh' -print0 | xargs -0 shellcheck
+	find . -name '*.sh' -print0 | xargs -0 shellcheck --exclude=SC1090,SC1091
 
 fmt-check:
 	shfmt -d .


### PR DESCRIPTION
## Summary
- align shellcheck invocation with modular shell architecture using dynamic `source` paths
- explicitly exclude `SC1090` and `SC1091` in CI shellcheck command
- mirror same exclusions in `Makefile` lint target
- update `.shellcheckrc` documentation for these exclusions

## Why
`install_security_tools.sh` and module installers source runtime-dependent paths, which trigger SC1090/SC1091 false positives in this repo design.

## Validation
- containerized run: `find . -name '*.sh' -print0 | xargs -0 shellcheck --exclude=SC1090,SC1091` (pass)
