### PR TITLE
docs: sync repo docs to v1.6.0 — browser-harness and seleniumbase spider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`scripts/news_spider_seleniumbase.py`** — SeleniumBase UC mode news spider for bot-protected sites. Targets Reuters and TASS (blocked by plain headless Chromium). Sequential captures only (no concurrency); UC mode bypasses Cloudflare/bot detection. Requires: `bash install_security_tools.sh seleniumbase`. Flags: `--site`, `--url`, `--include-pattern`, `--max-pages`, `--output-pdf`, `--dry-run`.
+
 ## [1.6.0] - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`scripts/news_spider_seleniumbase.py`** — SeleniumBase UC mode news spider for bot-protected sites. Targets Reuters and TASS (blocked by plain headless Chromium). Sequential captures only (no concurrency); UC mode bypasses Cloudflare/bot detection. Requires: `bash install_security_tools.sh seleniumbase`. Flags: `--site`, `--url`, `--include-pattern`, `--max-pages`, `--output-pdf`, `--dry-run`.
+- **`scripts/news_spider_seleniumbase.py`** — SeleniumBase UC mode news spider for bot-protected sites. Targets Reuters and TASS (blocked by plain headless Chromium). Sequential captures only (no concurrency); UC mode bypasses Cloudflare/bot detection. Requires: `bash install_security_tools.sh seleniumbase`. Flags: `--site`, `--url`, `--include-pattern`, `--max-pages`, `--output-pdf`, `--output-mhtml`, `--dry-run`.
 
 ## [1.6.0] - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ python3 scripts/news_spider_playwright.py --site bbc --max-pages 2
 python3 scripts/news_spider_playwright.py --site nikkei --output-pdf --output-mhtml
 
 # News Spider — SeleniumBase UC mode (Reuters, TASS — bypasses bot detection)
+python3 scripts/news_spider_seleniumbase.py --site reuters --dry-run
 python3 scripts/news_spider_seleniumbase.py --site reuters --max-pages 3
 python3 scripts/news_spider_seleniumbase.py --site tass --output-pdf
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A comprehensive user-space installation system for OSINT/CTI/PenTest and web aut
 
 ## 🎯 Features
 
-- ✅ **37 security tools** — OSINT, CTI, reconnaissance, pentesting, web automation
+- ✅ **38 security tools** — OSINT, CTI, reconnaissance, pentesting, web automation
 - ✅ **No sudo required** — complete user-space installation
 - ✅ **Pre-built binaries** — fast installs via GitHub releases; compile-from-source as fallback
 - ✅ **Use-case categories** — install exactly what you need with one command
@@ -20,7 +20,7 @@ A comprehensive user-space installation system for OSINT/CTI/PenTest and web aut
 - ✅ **XDG compliant** — follows Linux filesystem standards
 - ✅ **Shellcheck clean** — zero warnings across all scripts
 - ✅ **Detached GUI launchers** — GUI tools (`chrome`, `yandex-browser`, `tor-browser`, `qtox`, `spiderfoot`) background automatically using `nohup` + `disown`; guard checks verify binary presence and `DISPLAY` before launching
-- ✅ **News spider script** — `scripts/news_spider_playwright.py` captures screenshots, PDFs, and MHTML snapshots of news sites (BBC, Nikkei, Google News); no installer entry needed
+- ✅ **News spider scripts** — `scripts/news_spider_playwright.py` (BBC, Nikkei, Google News) and `scripts/news_spider_seleniumbase.py` (Reuters, TASS via UC mode) capture screenshots, PDFs, and MHTML snapshots; no installer entry needed
 
 ---
 
@@ -40,7 +40,7 @@ bash install_security_tools.sh --domain-tools     # Domain & Subdomain Enum (3 t
 bash install_security_tools.sh --recon-tools      # Active Recon & Scanning (4 tools)
 bash install_security_tools.sh --cti-tools        # Cyber Threat Intel (5 tools)
 bash install_security_tools.sh --utility-tools    # Utilities (6 tools)
-bash install_security_tools.sh --web-tools        # Web Tools (5 tools)
+bash install_security_tools.sh --web-tools        # Web Tools (6 tools)
 bash install_security_tools.sh all               # Everything
 ```
 
@@ -75,7 +75,7 @@ Tools are organized by use-case. → **[Full tool list with descriptions](https:
 | Cyber Threat Intelligence | shodan, censys, yara, trufflehog, virustotal | `--cti-tools` |
 | Security Testing | jwt-cracker | — |
 | Utilities | ripgrep, fd, bat, sd, doggo, aria2 | `--utility-tools` |
-| Web Tools | SeleniumBase, Playwright, Yandex Browser, Tor Browser, qTox | `--web-tools` |
+| Web Tools | SeleniumBase, Playwright, Yandex Browser, Tor Browser, qTox, browser-harness | `--web-tools` |
 
 ---
 
@@ -126,7 +126,7 @@ bash install_security_tools.sh --osint-tools --cti-tools
 | **[Wiki: Tool Categories](https://github.com/salesengr/tilix-tools-installer/wiki/Tool-Categories)** | Full tool list with descriptions |
 | **[Wiki: CLI Reference](https://github.com/salesengr/tilix-tools-installer/wiki/CLI-Reference)** | All flags, options, examples |
 | **[Wiki: Usage Examples](https://github.com/salesengr/tilix-tools-installer/wiki/Usage-Examples)** | Practical examples for every tool |
-| **[Wiki: Web Tools](https://github.com/salesengr/tilix-tools-installer/wiki/Web-Tools)** | SeleniumBase, Playwright, Yandex Browser, Tor Browser, qTox |
+| **[Wiki: Web Tools](https://github.com/salesengr/tilix-tools-installer/wiki/Web-Tools)** | SeleniumBase, Playwright, Yandex Browser, Tor Browser, qTox, browser-harness |
 | **[Wiki: Troubleshooting](https://github.com/salesengr/tilix-tools-installer/wiki/Troubleshooting)** | Common issues and fixes |
 | **[Wiki: Disk Space & Performance](https://github.com/salesengr/tilix-tools-installer/wiki/Disk-Space-and-Performance)** | Sizes and install times |
 | **[docs/EXTENDING_THE_SCRIPT.md](docs/EXTENDING_THE_SCRIPT.md)** | How to add new tools (versioned) |
@@ -169,9 +169,13 @@ tor-browser                                  # launch Tor Browser detached (nohu
 qtox                                         # launch qTox detached
 sbase get https://example.com --headless      # SeleniumBase headless screenshot
 
-# News Spider
+# News Spider — Playwright (BBC, Nikkei, Google News)
 python3 scripts/news_spider_playwright.py --site bbc --max-pages 2
 python3 scripts/news_spider_playwright.py --site nikkei --output-pdf --output-mhtml
+
+# News Spider — SeleniumBase UC mode (Reuters, TASS — bypasses bot detection)
+python3 scripts/news_spider_seleniumbase.py --site reuters --max-pages 3
+python3 scripts/news_spider_seleniumbase.py --site tass --output-pdf
 ```
 
 > **Playwright note:** `bash install_security_tools.sh playwright` downloads both the Python package and the Chromium binary (~300 MB) automatically — no separate `playwright install chromium` step required.

--- a/docs/tool_installation_summary.md
+++ b/docs/tool_installation_summary.md
@@ -271,4 +271,4 @@ python3 scripts/news_spider_seleniumbase.py \
     --include-pattern "/article/[a-z0-9-]+"
 ```
 
-**Output per run:** `<slug>.png`, `<slug>.pdf`, `summary.txt`, `run.log`
+**Output per run:** `<slug>.png`, `<slug>.pdf`, `<slug>.mhtml`, `summary.txt`, `run.log`

--- a/docs/tool_installation_summary.md
+++ b/docs/tool_installation_summary.md
@@ -248,7 +248,7 @@ python3 scripts/news_spider_playwright.py \
     --include-pattern "/article/[a-z0-9-]+"
 ```
 
-**Output per run:** `<slug>.png`, `<slug>.pdf`, `<slug>.mhtml`, `summary.txt`, `run.log`
+**Output per run:** `<slug>.png`, `<slug>.pdf`, `<slug>.mhtml`, `phase1-index.png`, `summary.txt`, `run.log`
 
 ### news_spider_seleniumbase.py
 
@@ -271,4 +271,4 @@ python3 scripts/news_spider_seleniumbase.py \
     --include-pattern "/article/[a-z0-9-]+"
 ```
 
-**Output per run:** `<slug>.png`, `<slug>.pdf`, `<slug>.mhtml`, `summary.txt`, `run.log`
+**Output per run:** `<slug>.png`, `<slug>.pdf`, `<slug>.mhtml`, `phase1-index.png`, `summary.txt`, `run.log`

--- a/docs/tool_installation_summary.md
+++ b/docs/tool_installation_summary.md
@@ -152,6 +152,7 @@ Web automation tools enable browser-based OSINT, stealth scraping, captcha bypas
 | Yandex Browser | `apt` via `repo.yandex.ru` | `/usr/bin/yandex-browser-beta` + `~/.local/bin/yandex-browser` |
 | Tor Browser | tarball from `torproject.org/dist/torbrowser/` | `~/opt/tor-browser/Browser/start-tor-browser` + `~/.local/bin/tor-browser` |
 | qTox | AppImage extract from `github.com/TokTok/qTox` | `~/opt/qtox/squashfs-root/AppRun` + `~/.local/bin/qtox` |
+| browser-harness | `git clone` + `uv tool install -e` to `~/opt/browser-harness`; `uv` auto-installed | `~/.local/bin/browser-harness` |
 
 ### SeleniumBase
 Works with the system Chrome already in the Tilix image. Three modes:
@@ -223,6 +224,7 @@ Scripts in the `scripts/` directory run directly from the repo and do not create
 | Script | Requires | Description |
 |--------|----------|-------------|
 | `scripts/news_spider_playwright.py` | `playwright` (via `bash install_security_tools.sh playwright`) | Captures screenshots, PDFs, and MHTML snapshots of news sites |
+| `scripts/news_spider_seleniumbase.py` | `seleniumbase` (via `bash install_security_tools.sh seleniumbase`) | UC mode spider for bot-protected sites (Reuters, TASS) |
 
 ### news_spider_playwright.py
 
@@ -247,3 +249,26 @@ python3 scripts/news_spider_playwright.py \
 ```
 
 **Output per run:** `<slug>.png`, `<slug>.pdf`, `<slug>.mhtml`, `summary.txt`, `run.log`
+
+### news_spider_seleniumbase.py
+
+SeleniumBase UC mode spider for bot-protected news sites. Uses undetected-chromedriver to bypass Cloudflare and similar bot detection — the complement to the Playwright spider for sites that block plain headless Chromium. Captures are sequential (no concurrency) because UC mode requires browser restarts between sessions.
+
+**Working presets:** `reuters`, `tass`
+
+```bash
+# Install prerequisites
+bash install_security_tools.sh seleniumbase
+
+# Run
+python3 scripts/news_spider_seleniumbase.py --site reuters --max-pages 3
+python3 scripts/news_spider_seleniumbase.py --site tass --output-pdf
+python3 scripts/news_spider_seleniumbase.py --site reuters --dry-run
+
+# Custom site
+python3 scripts/news_spider_seleniumbase.py \
+    --url https://example.com \
+    --include-pattern "/article/[a-z0-9-]+"
+```
+
+**Output per run:** `<slug>.png`, `<slug>.pdf`, `summary.txt`, `run.log`


### PR DESCRIPTION
## Summary

- **README**: bump tool count 37→38, add browser-harness to web tools table and wiki reference, expand news spider feature bullet to cover `news_spider_seleniumbase.py`, add UC spider examples to Quick Usage section
- **docs/tool_installation_summary.md**: add browser-harness to web tools table; add `news_spider_seleniumbase.py` to standalone scripts table with full usage section (presets, flags, output format)
- **CHANGELOG**: add `[Unreleased]` entry for `news_spider_seleniumbase.py`

## Test plan

- [ ] Review README web tools table includes browser-harness (6 tools)
- [ ] Review README tool count shows 38
- [ ] Review CHANGELOG [Unreleased] entry is accurate
- [ ] Review tool_installation_summary.md standalone scripts section covers both spiders

🤖 Generated with [Claude Code](https://claude.com/claude-code)